### PR TITLE
fix 19 - Code tweaks to get running on cm5 historical

### DIFF
--- a/drive_density.py
+++ b/drive_density.py
@@ -62,7 +62,8 @@ outPath     = '/work/guilyardi/git/Density_bining/test_cmip5'
 
 # Create logfile
 timeFormat = datetime.datetime.now().strftime("%y%m%d_%H%M%S")
-logPath = '/work/guilyardi/git/Density_bining/'
+#logPath = '/work/guilyardi/git/Density_bining/'
+logPath = '/export/durack1/git/Density_bining/'
 logfile = os.path.join(logPath,"".join([timeFormat,'_drive_density-',modelSuite,'-',experiment,'-',gethostname().split('.')[0],'.log'])) ; # WORK MODE
 writeToLog(logfile,"".join(['TIME: ',timeFormat]))
 writeToLog(logfile,"".join(['HOSTNAME: ',gethostname()]))
@@ -202,8 +203,8 @@ del(tmp,count,x) ; gc.collect()
 # EC-EARTH.historical.r10i1p1 - 55
 # MIROC4h.historical.r1i1p1 - 160
 #modelInd = [0,5,55,150,160] ; # Test suite to capture all errors
-modelInd = [0,5,150,160] ; # Test suite to capture all errors
-modelInd = [55] ; # Test suite to capture all errors
+modelInd = [0,5,55,150,160] ; # Test suite to capture all errors
+#modelInd = [160] ; # Test suite to capture all errors
 list_sht = []
 for count,x in enumerate(list_soAndthetaoAndfx):
     if count in modelInd:


### PR DESCRIPTION
@eguil this code, based off your branch we were working on today successfully runs across the 5 model test case (ACCESS1-0, BNU-ESM, EC-EARTH, IPSL-CM5A-LR and MIROC4h). I'm a little uncertain about the results from MIROC4h for example, the masking may still be an issue with this (and potentially other) models..

Let me know if this looks good and you can merge my changes, make any final tweaks you want and then let me know when you pull your changes back across and get this running..

I've left all the commented code tidyup to you, as it might be insightful as to how I was trying to test this to get it running..
